### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL scheme check

### DIFF
--- a/public/js/lang.js
+++ b/public/js/lang.js
@@ -185,7 +185,9 @@
       if (
         lowered.startsWith("mailto:") ||
         lowered.startsWith("tel:") ||
-        lowered.startsWith("javascript:")
+        lowered.startsWith("javascript:") ||
+        lowered.startsWith("data:") ||
+        lowered.startsWith("vbscript:")
       ) {
         return;
       }


### PR DESCRIPTION
Potential fix for [https://github.com/create-juicey-app/juicebox/security/code-scanning/1](https://github.com/create-juicey-app/juicebox/security/code-scanning/1)

To fix the incomplete URL scheme check, we should modify the affected check in `rewriteLinks` (file: public/js/lang.js, line 188) so that it blocks not only `javascript:` URLs, but also `data:` and `vbscript:` URLs. This is done by extending the conditional to include `lowered.startsWith("data:")` and `lowered.startsWith("vbscript:")`, in a case-insensitive manner that matches the current logic flow. No additional imports are needed, as these string checks suffice.

Only the conditional on line 185–189 needs to be changed, within `rewriteLinks`. No other functional changes or unrelated code should be altered.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
